### PR TITLE
Add basic Jest test for sessioninfo endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,4 +86,10 @@ app.use((err, req, res, next) => {
   res.status(500).send("Internal error: " + err.message);
 });
 
-app.listen(apiPort, () => console.log(`API Server listening on port ${apiPort}`));
+if (require.main === module) {
+  app.listen(apiPort, () =>
+    console.log(`API Server listening on port ${apiPort}`)
+  );
+}
+
+module.exports = app;

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,9 @@
+const request = require('supertest');
+const app = require('./index');
+
+describe('GET /sessioninfo', () => {
+  it('responds with 401 when no session cookie is present', async () => {
+    const res = await request(app).get('/sessioninfo');
+    expect(res.status).toBe(401);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gadgeteria",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "supertest": "^6.3.4"
+  }
+}


### PR DESCRIPTION
## Summary
- export Express app from index.js when required as a module
- add Jest-based integration test for `/sessioninfo`
- define test script and dev dependencies for Jest and Supertest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451de1fbe08323b714bd8c281fe8a5