### PR TITLE
Improve password security and simplify cart storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ A demo e-commerce project combining a PHP front-end with a Node.js backend for a
 1. Copy `.env.example` to `.env` and provide the necessary credentials.
 2. Install Node dependencies with `npm install`.
 3. Start the backend server using `npm start`.
+4. Ensure a `cart` table exists in your `appliances` database:
+   ```sql
+   CREATE TABLE cart (
+       id INT AUTO_INCREMENT PRIMARY KEY,
+       username VARCHAR(100) NOT NULL,
+       product_id VARCHAR(100) NOT NULL,
+       name VARCHAR(100) NOT NULL,
+       price INT NOT NULL,
+       quantity INT NOT NULL
+   );
+   ```
 
 ## Testing
 

--- a/admincheck.php
+++ b/admincheck.php
@@ -12,13 +12,14 @@ $pass1= stripslashes($pass2);
 
 $name = mysqli_real_escape_string($link,$name1);
 $pass = mysqli_real_escape_string($link,$pass1);
-$encp =  sha1($pass); 
 
+$stmt = mysqli_prepare($link, "SELECT password FROM admin WHERE username = ?");
+mysqli_stmt_bind_param($stmt, "s", $name);
+mysqli_stmt_execute($stmt);
+$result = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_assoc($result);
 
-$log = " select * from admin where username='$name' and password='$encp' ";
-$log1 = mysqli_query($link,$log); 
-
-if( mysqli_fetch_assoc($log1)){ 
+if($row && password_verify($pass, $row['password'])){
     if(isset($_REQUEST['rem'])){
         setcookie("username", $name , time()+60*60*24 , '/' , 'localhost');
     }

--- a/cart.php
+++ b/cart.php
@@ -141,16 +141,16 @@ echo "
 		    ?>
 		        <?php
                     
-					require_once('connect.php');
-					$log_ = ' select name from '.$_SESSION['uname'].' ';
-					$log_1 = mysqli_query($link,$log_);
-		      		$log = ' select * from '.$_SESSION['uname'].' ';
-		      		$log1 = mysqli_query($link,$log); 
-                    if(mysqli_num_rows( $log1) > 0 ){
-                    while($row = mysqli_fetch_array($log1)) {
+                                        require_once('connect.php');
+                                        $stmt = mysqli_prepare($link, "select * from cart where username = ?");
+                                        mysqli_stmt_bind_param($stmt, "s", $_SESSION['uname']);
+                                        mysqli_stmt_execute($stmt);
+                                        $log1 = mysqli_stmt_get_result($stmt);
+                    $rows = mysqli_fetch_all($log1, MYSQLI_ASSOC);
+                    foreach($rows as $row){
                     echo $row['product_id']." - ".$row['name']."<hr class='f4'><br>";
 
-                    }}
+                    }
 		      	
 		      	
 		     echo " 		
@@ -161,13 +161,15 @@ echo "
 
 		        <?php
                          
-		      		$log = ' select * from '.$_SESSION['uname'].' ';
-		      		$log1 = mysqli_query($link,$log); 
-                    if(mysqli_num_rows( $log1) > 0 ){
-                    while($row = mysqli_fetch_array($log1)) {
+                                $stmt = mysqli_prepare($link, "select * from cart where username = ?");
+                                mysqli_stmt_bind_param($stmt, "s", $_SESSION['uname']);
+                                mysqli_stmt_execute($stmt);
+                                $log1 = mysqli_stmt_get_result($stmt);
+                    $rows = mysqli_fetch_all($log1, MYSQLI_ASSOC);
+                    foreach($rows as $row){
                     echo $row['quantity']."<hr class='f4'><br>" ;
 
-                    }}
+                    }
 		      	echo"
 		    </td>
 		      		
@@ -176,16 +178,18 @@ echo "
 
 		      	<?php
 		      				
-		      	    $sum=0;
-                    $log = ' select * from '.$_SESSION['uname'].' ';
-		      	    $log1 = mysqli_query($link,$log); 
-                    if(mysqli_num_rows( $log1) > 0 ){
-                    while($row = mysqli_fetch_array($log1)) {
-        	        $amt=$row['price']*$row['quantity'];
+                    $sum=0;
+                    $stmt = mysqli_prepare($link, "select * from cart where username = ?");
+                            mysqli_stmt_bind_param($stmt, "s", $_SESSION['uname']);
+                            mysqli_stmt_execute($stmt);
+                            $log1 = mysqli_stmt_get_result($stmt);
+                    $rows = mysqli_fetch_all($log1, MYSQLI_ASSOC);
+                    foreach($rows as $row){
+                        $amt=$row['price']*$row['quantity'];
                     echo "Rs.".$amt."<hr class='f4'><br>" ;
                     $sum=$sum+$amt;
-		      				
-                    }}
+
+                    }
 		      			
 		      	
 		      			
@@ -252,3 +256,4 @@ echo "
        }
            
 ?>
+

--- a/check.php
+++ b/check.php
@@ -12,21 +12,19 @@ $pass1= stripslashes($pass2);
 
 $name = mysqli_real_escape_string($link,$name1);
 $pass = mysqli_real_escape_string($link,$pass1);
-$encp =  sha1($pass); 
 
+$stmt = mysqli_prepare($link, "SELECT password FROM register WHERE username = ?");
+mysqli_stmt_bind_param($stmt, "s", $name);
+mysqli_stmt_execute($stmt);
+$result = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_assoc($result);
 
-$log = " select * from register where username='$name' and password='$encp' ";
-$log1 = mysqli_query($link,$log); 
-
-if( mysqli_fetch_assoc($log1)){ 
+if($row && password_verify($pass, $row['password'])){
     if(isset($_REQUEST['rem'])){
         setcookie("username", $name , time()+60*60*24 , '/' , 'localhost');
     }
     $_SESSION['login'] = true;
     $_SESSION['uname']=$name;
-
-    $query3 = "CREATE TABLE IF NOT EXISTS " . $_SESSION['uname'] . "( product_id VARCHAR(100) NOT NULL , name VARCHAR(100) NOT NULL , price INT(100) NOT NULL , quantity INT(100) NOT NULL , PRIMARY KEY (product_id)) ENGINE = InnoDB";
-    $result3 = mysqli_query($link,$query3); 
 
     echo "
             <script>

--- a/chpass.php
+++ b/chpass.php
@@ -3,12 +3,15 @@
     $name = $_REQUEST["uname2"]; 
 	$newpwd = $_REQUEST["pass2"]; 
 	$mail= $_REQUEST["email2"];
-	 $enpwd =  sha1( $newpwd );
-	 $query = "select * from register where username = '$name' and email='$mail'"; 
-        $result = mysqli_query( $link, $query ) or die( mysqli_error($link) );
-	 if(mysqli_num_rows($result) == 1){ 
-	  	$update = " update register set password = '$enpwd' WHERE username = '$name'";
-               mysqli_query( $link, $update ) or die( mysqli_error($link) );
+         $query = mysqli_prepare($link, "select * from register where username = ? and email = ?");
+        mysqli_stmt_bind_param($query, "ss", $name, $mail);
+        mysqli_stmt_execute($query);
+        $result = mysqli_stmt_get_result($query);
+         if(mysqli_num_rows($result) == 1){
+                $enpwd = password_hash( $newpwd , PASSWORD_DEFAULT);
+                $update = mysqli_prepare($link, " update register set password = ? WHERE username = ?");
+               mysqli_stmt_bind_param($update, "ss", $enpwd, $name);
+               mysqli_stmt_execute( $update );
         echo "
             <script>
                 window.location='index.php';

--- a/clear.php
+++ b/clear.php
@@ -3,8 +3,9 @@ require_once('connect.php');
 session_start(); 
 if(isset($_SESSION['login']) && $_SESSION['login'] == true){ 
 
-	 $log = " DELETE FROM ".$_SESSION['uname']." ";
-     $log1 = mysqli_query($link,$log);  
+         $log = mysqli_prepare($link, "DELETE FROM cart WHERE username = ?");
+     mysqli_stmt_bind_param($log, "s", $_SESSION['uname']);
+     mysqli_stmt_execute($log);
      header('location:cart.php');
  }
 
@@ -12,3 +13,4 @@ if(isset($_SESSION['login']) && $_SESSION['login'] == true){
            header('location:login.php');
      }           
 ?>
+

--- a/confirm.php
+++ b/confirm.php
@@ -210,12 +210,14 @@ echo "
 		      		?>
 		      			<?php
                             require_once('connect.php');
-		      				$log = 'select * from '.$_SESSION['uname'].' ';
-		      				$log1 = mysqli_query($link,$log); 
-                            if(mysqli_num_rows( $log1) > 0 ){
-                            while($row = mysqli_fetch_array($log1)) {
+                                                $stmt = mysqli_prepare($link, "select * from cart where username = ?");
+                                                mysqli_stmt_bind_param($stmt, "s", $_SESSION['uname']);
+                                                mysqli_stmt_execute($stmt);
+                                                $log1 = mysqli_stmt_get_result($stmt);
+                            $rows = mysqli_fetch_all($log1, MYSQLI_ASSOC);
+                            foreach($rows as $row) {
                             echo $row['product_id']." - ".$row['name']."<hr class='f4'><br>";
-                            }}
+                            }
 		      			
 		      	echo "
 		      		
@@ -226,12 +228,14 @@ echo "
 
 		      			<?php
                          
-		      				$log = ' select * from '.$_SESSION['uname'].' ';
-		      				$log1 = mysqli_query($link,$log); 
-                            if(mysqli_num_rows( $log1) > 0 ){
-                            while($row = mysqli_fetch_array($log1)) {
+                                                $stmt = mysqli_prepare($link, " select * from cart where username = ?");
+                                                mysqli_stmt_bind_param($stmt, "s", $_SESSION['uname']);
+                                                mysqli_stmt_execute($stmt);
+                                                $log1 = mysqli_stmt_get_result($stmt);
+                            $rows = mysqli_fetch_all($log1, MYSQLI_ASSOC);
+                            foreach($rows as $row) {
                             echo $row['quantity']."<hr class='f4'><br>" ;
-                            }}
+                            }
 		      		echo "
 		      			
 		      		</td>
@@ -240,16 +244,18 @@ echo "
 		      		";
 		      		?>
 		      			<?php
-		      				$sum=0;
-                            $log = 'select * from '.$_SESSION['uname'].' ';
-		      				$log1 = mysqli_query($link,$log); 
-                            if(mysqli_num_rows( $log1) > 0 ){
-                            while($row = mysqli_fetch_array($log1)) {
-        	                $amt=$row['price']*$row['quantity'];
+                                                $sum=0;
+                            $stmt = mysqli_prepare($link, "select * from cart where username = ?");
+                                                mysqli_stmt_bind_param($stmt, "s", $_SESSION['uname']);
+                                                mysqli_stmt_execute($stmt);
+                                                $log1 = mysqli_stmt_get_result($stmt);
+                            $rows = mysqli_fetch_all($log1, MYSQLI_ASSOC);
+                            foreach($rows as $row) {
+                                $amt=$row['price']*$row['quantity'];
                             echo "Rs.".$amt."<hr class='f4'><br>";
                             $sum=$sum+$amt;
 		      				
-                            }}
+                            }
 		      			echo "
 		      			
 		      		</td>
@@ -312,3 +318,4 @@ echo "
        }
            
 ?>
+

--- a/del.php
+++ b/del.php
@@ -1,55 +1,56 @@
 <?php
 	require_once('connect.php');
-	$table=$_REQUEST['tablename'];	
-	$productid=$_REQUEST['productid'];	
-	
+        $table=$_REQUEST['tablename'];
+        $productid=$_REQUEST['productid'];
 
-
-	
-	$query1 = "select * from $table where product_id='$productid'";
-	$dup1=mysqli_query($link,$query1);
-		if( mysqli_num_rows($dup1)==0)  { 
-		    echo "<script> 
+        if(in_array($table, ['mobile','laptop','watch','television'])){
+        $stmt = mysqli_prepare($link, "select * from $table where product_id = ?");
+        mysqli_stmt_bind_param($stmt, "s", $productid);
+        mysqli_stmt_execute($stmt);
+        $dup1 = mysqli_stmt_get_result($stmt);
+                if( mysqli_num_rows($dup1)==0)  {
+                    echo "<script>
                 alert('Product ID doesnt exists');
                 window.location='delete.php';
-                </script>";  
-		}  
-	    else { 
+                </script>";
+                }
+            else {
+            $del = mysqli_prepare($link, " delete from $table where product_id=?");
+            mysqli_stmt_bind_param($del, "s", $productid);
+            mysqli_stmt_execute($del);
             if($table=='mobile'){
-		        $query = " delete from $table where product_id='$productid'";
-				$result = mysqli_query($link,$query);
                 echo "<script>
-                	window.location='mobile.php';
+                        window.location='mobile.php';
                 </script>";
             }
             else if($table=='laptop'){
-		        $query = " delete from $table where product_id='$productid'";
-				$result = mysqli_query($link,$query);
                 echo "<script>
-                	window.location='laptop.php';
+                        window.location='laptop.php';
                 </script>";
             }
             else if($table=='watch'){
-		        $query = " delete from $table where product_id='$productid'";
-				$result = mysqli_query($link,$query);
                 echo "<script>
-                	window.location='watch.php';
+                        window.location='watch.php';
                 </script>";
             }
             else if($table=='television'){
-		        $query = " delete from $table where product_id='$productid'";
-				$result = mysqli_query($link,$query);
                 echo "<script>
-                	window.location='tv.php';
+                        window.location='tv.php';
                 </script>";
             }
             else{
                 echo "<script>
                         alert('No Table Exists');
-                		window.location='delete.php';
+                                window.location='delete.php';
                     </script>";
                 }
             }
+        } else {
+            echo "<script>
+                    alert('No Table Exists');
+                            window.location='delete.php';
+                </script>";
+        }
 ?>
 
 

--- a/ed.php
+++ b/ed.php
@@ -23,25 +23,35 @@ $redirects = [
     'television' => 'tv.php'
 ];
 
-$query = "select * from $table where product_id='$productid'";
-$dup   = mysqli_query($link, $query);
+$query = mysqli_prepare($link, "select * from $table where product_id=?");
+mysqli_stmt_bind_param($query, "s", $productid);
+mysqli_stmt_execute($query);
+$dup   = mysqli_stmt_get_result($query);
 
 if (mysqli_num_rows($dup) == 0) {
     echo "<script> alert('Product ID doesnt exist.'); window.location='edit.php'; </script>";
 } elseif (isset($nameColumns[$table])) {
     $nameCol = $nameColumns[$table];
 
-    $query1 = "update $table set $nameCol='$name' where product_id='$productid'";
-    $query2 = "update $table set image='$image' where product_id='$productid'";
-    $query3 = "update $table set size='$si' where product_id='$productid'";
-    $query4 = "update $table set description='$description' where product_id='$productid'";
-    $query5 = "update $table set price=$price where product_id='$productid'";
+    $query1 = mysqli_prepare($link, "update $table set $nameCol=? where product_id=?");
+    mysqli_stmt_bind_param($query1, "ss", $name, $productid);
+    mysqli_stmt_execute($query1);
 
-    mysqli_query($link, $query1);
-    mysqli_query($link, $query2);
-    mysqli_query($link, $query3);
-    mysqli_query($link, $query4);
-    mysqli_query($link, $query5);
+    $query2 = mysqli_prepare($link, "update $table set image=? where product_id=?");
+    mysqli_stmt_bind_param($query2, "ss", $image, $productid);
+    mysqli_stmt_execute($query2);
+
+    $query3 = mysqli_prepare($link, "update $table set size=? where product_id=?");
+    mysqli_stmt_bind_param($query3, "ss", $si, $productid);
+    mysqli_stmt_execute($query3);
+
+    $query4 = mysqli_prepare($link, "update $table set description=? where product_id=?");
+    mysqli_stmt_bind_param($query4, "ss", $description, $productid);
+    mysqli_stmt_execute($query4);
+
+    $query5 = mysqli_prepare($link, "update $table set price=? where product_id=?");
+    mysqli_stmt_bind_param($query5, "is", $price, $productid);
+    mysqli_stmt_execute($query5);
 
     $redirect = $redirects[$table];
     echo "<script> window.location='$redirect'; </script>";

--- a/ins.php
+++ b/ins.php
@@ -1,58 +1,69 @@
 <?php
 	require_once('connect.php');
-	$table=$_REQUEST['tablename'];	
-	$name=$_REQUEST['name'];	
-	$productid=$_REQUEST['productid'];	
-	$image=$_REQUEST['image'];	
-	$price=$_REQUEST['price'];	
-	$si=$_REQUEST['size'];	
-	$description=$_REQUEST['description'];	
+        $table=$_REQUEST['tablename'];
+        $name=$_REQUEST['name'];
+        $productid=$_REQUEST['productid'];
+        $image=$_REQUEST['image'];
+        $price=$_REQUEST['price'];
+        $si=$_REQUEST['size'];
+        $description=$_REQUEST['description'];
 
-
-	
-	$query = "select * from $table where product_id='$productid'";
-	$dup=mysqli_query($link,$query);
-		if( mysqli_num_rows($dup)>=1)  { 
-		    echo "<script> alert('Product ID already exists.');
+        if(in_array($table,['mobile','laptop','watch','television'])){
+        $stmt = mysqli_prepare($link, "select * from $table where product_id=?");
+        mysqli_stmt_bind_param($stmt, "s", $productid);
+        mysqli_stmt_execute($stmt);
+        $dup=mysqli_stmt_get_result($stmt);
+                if( mysqli_num_rows($dup)>=1)  {
+                    echo "<script> alert('Product ID already exists.');
                 window.location='insert.php';
-             </script>";  
-		}  
-	    else { 
+             </script>";
+                }
+            else {
             if($table=='mobile'){
-		        $query = "insert into mobile values('$name','$si','$productid',$price,'$image','$description')";
-				$result = mysqli_query($link,$query);
+                        $query = mysqli_prepare($link, "insert into mobile values (?,?,?,?,?,?)");
+                        mysqli_stmt_bind_param($query, "sssiss", $name, $si, $productid, $price, $image, $description);
+                        mysqli_stmt_execute($query);
                 echo "<script>
-                	window.location='mobile.php';
+                        window.location='mobile.php';
                 </script>";
             }
             else if($table=='laptop'){
-		        $query = "insert into laptop values('$name','$si','$productid',$price,'$image','$description')";
-				$result = mysqli_query($link,$query);
+                        $query = mysqli_prepare($link, "insert into laptop values (?,?,?,?,?,?)");
+                        mysqli_stmt_bind_param($query, "sssiss", $name, $si, $productid, $price, $image, $description);
+                        mysqli_stmt_execute($query);
                 echo "<script>
-                	window.location='laptop.php';
+                        window.location='laptop.php';
                 </script>";
             }
             else if($table=='watch'){
-		        $query = "insert into watch values('$name','$si','$productid',$price,'$image','$description')";
-				$result = mysqli_query($link,$query);
+                        $query = mysqli_prepare($link, "insert into watch values (?,?,?,?,?,?)");
+                        mysqli_stmt_bind_param($query, "sssiss", $name, $si, $productid, $price, $image, $description);
+                        mysqli_stmt_execute($query);
                 echo "<script>
-                	window.location='watch.php';
+                        window.location='watch.php';
                 </script>";
             }
             else if($table=='television'){
-		        $query = "insert into television values('$name','$si','$productid',$price,'$image','$description')";
-				$result = mysqli_query($link,$query);
+                        $query = mysqli_prepare($link, "insert into television values (?,?,?,?,?,?)");
+                        mysqli_stmt_bind_param($query, "sssiss", $name, $si, $productid, $price, $image, $description);
+                        mysqli_stmt_execute($query);
                 echo "<script>
-                	window.location='tv.php';
+                        window.location='tv.php';
                 </script>";
             }
             else{
                 echo "<script>
                         alert('No Table Exists');
-                		window.location='insert.php';
+                                window.location='insert.php';
                     </script>";
                 }
             }
+        } else {
+            echo "<script>
+                    alert('No Table Exists');
+                            window.location='insert.php';
+                </script>";
+        }
 ?>
 
 

--- a/lapcart.php
+++ b/lapcart.php
@@ -4,13 +4,16 @@ session_start();
     $n1=$_REQUEST['n1'];
     $_SESSION['quan']=$_REQUEST['quantity'];
 
-    $log = " select * from laptop where product_id ='$n1'";
-    $log1 = mysqli_query($link,$log); 
+    $log = mysqli_prepare($link, " select * from laptop where product_id = ?");
+    mysqli_stmt_bind_param($log, "s", $n1);
+    mysqli_stmt_execute($log);
+    $log1 = mysqli_stmt_get_result($log);
     if(mysqli_num_rows( $log1) > 0 ){
-        while($row = mysqli_fetch_array($log1)) {
-            $query1 = "INSERT INTO ".$_SESSION['uname']." values ('".$row['product_id']."','".$row['lname']."',".$row['price'].",".$_SESSION['quan'].")";
-            $result1 = mysqli_query($link,$query1);
+        while($row = mysqli_fetch_assoc($log1)) {
+            $query1 = mysqli_prepare($link, "INSERT INTO cart(username, product_id, name, price, quantity) values (?,?,?,?,?)");
+            mysqli_stmt_bind_param($query1, "sssii", $_SESSION['uname'], $row['product_id'], $row['lname'], $row['price'], $_SESSION['quan']);
+            mysqli_stmt_execute($query1);
             header("location:laptop.php");
-    }   
-    }        
+    }
+    }
     ?>

--- a/lapproduct.php
+++ b/lapproduct.php
@@ -65,10 +65,12 @@ if(isset($_SESSION['login']) && $_SESSION['login'] == true){
                                 <div class='thumbnail'>";
                                         require_once('connect.php');
                                         $n1=$_REQUEST['n1'];
-                                        $log = " select * from laptop where product_id ='$n1'";
-                                        $log1 = mysqli_query($link,$log); 
+                                        $stmt = mysqli_prepare($link, " select * from laptop where product_id = ?");
+                                        mysqli_stmt_bind_param($stmt, "s", $n1);
+                                        mysqli_stmt_execute($stmt);
+                                        $log1 = mysqli_stmt_get_result($stmt);
                                         if(mysqli_num_rows( $log1) > 0 ){
-                                            while($row = mysqli_fetch_array($log1)) {
+                                            while($row = mysqli_fetch_assoc($log1)) {
                                                 echo "<img class='img-responsive' src='".$row['image']."'>";
                                                 echo "<div class='caption'>
                                                     <h2 class='pull-right'>Rs. ".$row['price']."</h2>

--- a/mobcart.php
+++ b/mobcart.php
@@ -4,14 +4,17 @@ session_start();
     $n1=$_REQUEST['n1'];
     $_SESSION['quan']=$_REQUEST['quantity'];
 
-    $log = " select * from mobile where product_id ='$n1'";
-    $log1 = mysqli_query($link,$log); 
+    $log = mysqli_prepare($link, " select * from mobile where product_id = ?");
+    mysqli_stmt_bind_param($log, "s", $n1);
+    mysqli_stmt_execute($log);
+    $log1 = mysqli_stmt_get_result($log);
     if(mysqli_num_rows( $log1) > 0 ){
-        while($row = mysqli_fetch_array($log1)) {
-            $query1 = "INSERT INTO ".$_SESSION['uname']." values ('".$row['product_id']."','".$row['mname']."',".$row['price'].",".$_SESSION['quan'].")";
-                $result1 = mysqli_query($link,$query1);
+        while($row = mysqli_fetch_assoc($log1)) {
+            $query1 = mysqli_prepare($link, "INSERT INTO cart(username, product_id, name, price, quantity) values (?,?,?,?,?)");
+            mysqli_stmt_bind_param($query1, "sssii", $_SESSION['uname'], $row['product_id'], $row['mname'], $row['price'], $_SESSION['quan']);
+            mysqli_stmt_execute($query1);
             header("location:mobile.php");
 
-    }   
-    }        
+    }
+    }
     ?>

--- a/mobproduct.php
+++ b/mobproduct.php
@@ -64,11 +64,13 @@
 					        <div class='col-md-9' style='margin: 0 10%;'>
 					            <div class='thumbnail'>";
 										require_once('connect.php');
-										$n1=$_REQUEST['n1'];
-										$log = " select * from mobile where product_id ='$n1'";
-										$log1 = mysqli_query($link,$log); 
+                                        $n1=$_REQUEST["n1"];
+                                        $stmt = mysqli_prepare($link, " select * from mobile where product_id = ?");
+                                        mysqli_stmt_bind_param($stmt, "s", $n1);
+                                        mysqli_stmt_execute($stmt);
+                                        $log1 = mysqli_stmt_get_result($stmt);
 									    if(mysqli_num_rows( $log1) > 0 ){
-									        while($row = mysqli_fetch_array($log1)) {
+									        while($row = mysqli_fetch_assoc($log1)) {
 									            echo "<img class='img-responsive' src='".$row['image']."'>";
 								                echo "<div class='caption'>
 								                    <h2 class='pull-right'>Rs. ".$row['price']."</h2>

--- a/register.php
+++ b/register.php
@@ -6,12 +6,10 @@
 		$emad= $_REQUEST['ead'];
 		$pass= $_REQUEST['pass'];
 		$repass= $_REQUEST['repass'];
-		$encp =  sha1($pass); 
-		$encrep =  sha1($repass); 
-
-
-		$dup = "select * from register where username ='$name'";
-		$dup1 = mysqli_query($link,$dup); 
+                $dup = mysqli_prepare($link, "select * from register where username = ?");
+                mysqli_stmt_bind_param($dup, "s", $name);
+                mysqli_stmt_execute($dup);
+                $dup1 = mysqli_stmt_get_result($dup);
 
 		if( mysqli_num_rows($dup1) >=1)  { 
 		    echo "<script> alert('User name is already exists.');
@@ -20,9 +18,11 @@
 
 		}  
 	    else { 
-            if($encp==$encrep){
-		        $query = "insert into register values ('$name','$encp','$emad')";
-				$result = mysqli_query($link,$query);
+            if($pass==$repass){
+                        $encp = password_hash($pass, PASSWORD_DEFAULT);
+                        $query = mysqli_prepare($link, "insert into register(username,password,email) values (?,?,?)");
+                        mysqli_stmt_bind_param($query, "sss", $name, $encp, $emad);
+                        mysqli_stmt_execute($query);
                 echo "<script>
                     window.location='login.php';
                 </script>";

--- a/thank.php
+++ b/thank.php
@@ -88,8 +88,9 @@ echo "
   </div>
   </center>";
 
-      $log = " DELETE FROM ".$_SESSION['uname']." ";
-      $log1 = mysqli_query($link,$log);  
+      $log = mysqli_prepare($link, "DELETE FROM cart WHERE username = ?");
+      mysqli_stmt_bind_param($log, "s", $_SESSION['uname']);
+      mysqli_stmt_execute($log);
 
   echo "
 </body>
@@ -102,4 +103,5 @@ echo "
        }
            
 ?>
+
 

--- a/tvcart.php
+++ b/tvcart.php
@@ -3,14 +3,17 @@ require_once('connect.php');
 session_start();
     $n1=$_REQUEST['n1'];
     $_SESSION['quan']=$_REQUEST['quantity'];
-    $log = " select * from television where product_id ='$n1'";
-    $log1 = mysqli_query($link,$log); 
+    $log = mysqli_prepare($link, " select * from television where product_id = ?");
+    mysqli_stmt_bind_param($log, "s", $n1);
+    mysqli_stmt_execute($log);
+    $log1 = mysqli_stmt_get_result($log);
     if(mysqli_num_rows( $log1) > 0 ){
-        while($row = mysqli_fetch_array($log1)) {
-            $query1 = "INSERT INTO ".$_SESSION['uname']." values ('".$row['product_id']."','".$row['tname']."',".$row['price'].",".$_SESSION['quan'].")";
-                $result1 = mysqli_query($link,$query1);
+        while($row = mysqli_fetch_assoc($log1)) {
+            $query1 = mysqli_prepare($link, "INSERT INTO cart(username, product_id, name, price, quantity) values (?,?,?,?,?)");
+            mysqli_stmt_bind_param($query1, "sssii", $_SESSION['uname'], $row['product_id'], $row['tname'], $row['price'], $_SESSION['quan']);
+            mysqli_stmt_execute($query1);
             header("location:tv.php");
 
-    }   
-    }        
+    }
+    }
     ?>

--- a/tvproduct.php
+++ b/tvproduct.php
@@ -64,11 +64,13 @@
                             <div class='col-md-9' style='margin: 0 10%;'>
                                 <div class='thumbnail'>";
                                         require_once('connect.php');
-                                        $n1=$_REQUEST['n1'];
-                                        $log = " select * from television where product_id ='$n1'";
-                                        $log1 = mysqli_query($link,$log); 
+                                        $n1=$_REQUEST["n1"];
+                                        $stmt = mysqli_prepare($link, " select * from television where product_id = ?");
+                                        mysqli_stmt_bind_param($stmt, "s", $n1);
+                                        mysqli_stmt_execute($stmt);
+                                        $log1 = mysqli_stmt_get_result($stmt);
                                         if(mysqli_num_rows( $log1) > 0 ){
-                                            while($row = mysqli_fetch_array($log1)) {
+                                            while($row = mysqli_fetch_assoc($log1)) {
                                                 echo "<img class='img-responsive' src='".$row['image']."'>";
                                                 echo "<div class='caption'>
                                                     <h2 class='pull-right'>Rs. ".$row['price']."</h2>

--- a/watcart.php
+++ b/watcart.php
@@ -3,13 +3,16 @@ require_once('connect.php');
 session_start();
     $n1=$_REQUEST['n1'];
     $_SESSION['quan']=$_REQUEST['quantity'];
-    $log = " select * from watch where product_id ='$n1'";
-    $log1 = mysqli_query($link,$log); 
+    $log = mysqli_prepare($link, " select * from watch where product_id = ?");
+    mysqli_stmt_bind_param($log, "s", $n1);
+    mysqli_stmt_execute($log);
+    $log1 = mysqli_stmt_get_result($log);
     if(mysqli_num_rows( $log1) > 0 ){
-        while($row = mysqli_fetch_array($log1)) {
-            $query1 = "INSERT INTO ".$_SESSION['uname']." values ('".$row['product_id']."','".$row['wname']."',".$row['price'].",".$_SESSION['quan'].")";
-                $result1 = mysqli_query($link,$query1);
+        while($row = mysqli_fetch_assoc($log1)) {
+            $query1 = mysqli_prepare($link, "INSERT INTO cart(username, product_id, name, price, quantity) values (?,?,?,?,?)");
+            mysqli_stmt_bind_param($query1, "sssii", $_SESSION['uname'], $row['product_id'], $row['wname'], $row['price'], $_SESSION['quan']);
+            mysqli_stmt_execute($query1);
             header("location:watch.php");
-    }   
-    }        
+    }
+    }
     ?>

--- a/watproduct.php
+++ b/watproduct.php
@@ -64,11 +64,13 @@
                             <div class='col-md-9' style='margin: 0 10%;'>
                                 <div class='thumbnail'>";
                                         require_once('connect.php');
-                                        $n1=$_REQUEST['n1'];
-                                        $log = " select * from watch where product_id ='$n1'";
-                                        $log1 = mysqli_query($link,$log); 
+                                        $n1=$_REQUEST["n1"];
+                                        $stmt = mysqli_prepare($link, " select * from watch where product_id = ?");
+                                        mysqli_stmt_bind_param($stmt, "s", $n1);
+                                        mysqli_stmt_execute($stmt);
+                                        $log1 = mysqli_stmt_get_result($stmt);
                                         if(mysqli_num_rows( $log1) > 0 ){
-                                            while($row = mysqli_fetch_array($log1)) {
+                                            while($row = mysqli_fetch_assoc($log1)) {
                                                 echo "<img class='img-responsive' src='".$row['image']."'>";
                                                echo "<div class='caption'>
                                                     <h2 class='pull-right'>Rs. ".$row['price']."</h2>


### PR DESCRIPTION
## Summary
- hash passwords using `password_hash` and `password_verify`
- replace raw SQL with prepared statements
- remove per-user cart tables and use single `cart` table
- update cart scripts for new schema
- document new `cart` table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684523143d808323b654aee3896eb9b9