### PR TITLE
Add PHP environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ A demo e-commerce project combining a PHP front-end with a Node.js backend for a
 ## Setup
 
 1. Copy `.env.example` to `.env` and provide the necessary credentials.
-2. Install Node dependencies with `npm install`.
-3. Start the backend server using `npm start`.
+2. Copy `php/.env.example` to `php/.env` and add your database credentials.
+3. Run `composer install` to install PHP dependencies.
+4. Install Node dependencies with `npm install`.
+5. Start the backend server using `npm start`.
 
 ## Testing
 

--- a/connect.php
+++ b/connect.php
@@ -1,4 +1,19 @@
 <?php
-	$link = mysqli_connect("localhost","root","") or die("Connection Error");
-	mysqli_select_db($link,"appliances")or die("Connection Error");
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
+
+if (class_exists('Dotenv\\Dotenv')) {
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/php');
+    $dotenv->safeLoad();
+}
+
+$dbHost = getenv('DB_HOST') ?: 'localhost';
+$dbUser = getenv('DB_USER') ?: 'root';
+$dbPass = getenv('DB_PASSWORD') ?: '';
+$dbName = getenv('DB_NAME') ?: 'appliances';
+
+$link = mysqli_connect($dbHost, $dbUser, $dbPass) or die("Connection Error");
+mysqli_select_db($link, $dbName) or die("Connection Error");
 ?>

--- a/php/.env.example
+++ b/php/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=appliances


### PR DESCRIPTION
## Summary
- add a PHP `.env.example` with DB connection keys
- load env vars in `connect.php` (optional Dotenv support)
- document PHP env setup in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452315121483238c167addb0d75859