### PR TITLE
Add PHP dependencies to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,3 +1,12 @@
 {
-	
+    "name": "gadgeteria/app",
+    "description": "Gadgeteria demo e-commerce application",
+    "type": "project",
+    "require": {
+        "vlucas/phpdotenv": "^5.5",
+        "ext-mysqli": "*"
+    },
+    "autoload": {
+        "classmap": ["public/controllers/"]
+    }
 }


### PR DESCRIPTION
## Summary
- specify `vlucas/phpdotenv` and `ext-mysqli` in `composer.json`

## Testing
- `composer install` *(fails: composer not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_684530077f2c83238e46354ea3d39736