### PR TITLE
Fix password security in PHP scripts

### DIFF
--- a/public/controllers/check.php
+++ b/public/controllers/check.php
@@ -3,30 +3,25 @@
 session_start();
 require_once('connect.php');
         
-$name2= $_REQUEST['uname1'];
-$pass2= $_REQUEST['pass1'];
+$name = $_POST['uname1'] ?? '';
+$pass = $_POST['pass1'] ?? '';
 
+$stmt = mysqli_prepare($link, "SELECT password FROM register WHERE username = ?");
+mysqli_stmt_bind_param($stmt, 's', $name);
+mysqli_stmt_execute($stmt);
+$res = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_assoc($res);
 
-$name1 = stripslashes($name2);
-$pass1= stripslashes($pass2);
-
-$name = mysqli_real_escape_string($link,$name1);
-$pass = mysqli_real_escape_string($link,$pass1);
-$encp =  sha1($pass); 
-
-
-$log = " select * from register where username='$name' and password='$encp' ";
-$log1 = mysqli_query($link,$log); 
-
-if( mysqli_fetch_assoc($log1)){ 
+if($row && password_verify($pass, $row['password'])){
     if(isset($_REQUEST['rem'])){
         setcookie("username", $name , time()+60*60*24 , '/' , 'localhost');
     }
     $_SESSION['login'] = true;
     $_SESSION['uname']=$name;
 
-    $query3 = "CREATE TABLE IF NOT EXISTS " . $_SESSION['uname'] . "( product_id VARCHAR(100) NOT NULL , name VARCHAR(100) NOT NULL , price INT(100) NOT NULL , quantity INT(100) NOT NULL , PRIMARY KEY (product_id)) ENGINE = InnoDB";
-    $result3 = mysqli_query($link,$query3); 
+    $tableName = preg_replace('/[^A-Za-z0-9_]/', '', $_SESSION['uname']);
+    $query3 = "CREATE TABLE IF NOT EXISTS `" . $tableName . "`( product_id VARCHAR(100) NOT NULL , name VARCHAR(100) NOT NULL , price INT(100) NOT NULL , quantity INT(100) NOT NULL , PRIMARY KEY (product_id)) ENGINE = InnoDB";
+    mysqli_query($link,$query3);
 
     echo "
             <script>

--- a/public/controllers/chpass.php
+++ b/public/controllers/chpass.php
@@ -1,18 +1,21 @@
 <?php 
 	require_once('connect.php');
-    $name = $_REQUEST["uname2"]; 
-	$newpwd = $_REQUEST["pass2"]; 
-	$mail= $_REQUEST["email2"];
-	 $enpwd =  sha1( $newpwd );
-	 $query = "select * from register where username = '$name' and email='$mail'"; 
-        $result = mysqli_query( $link, $query ) or die( mysqli_error($link) );
-	 if(mysqli_num_rows($result) == 1){ 
-	  	$update = " update register set password = '$enpwd' WHERE username = '$name'";
-               mysqli_query( $link, $update ) or die( mysqli_error($link) );
-        echo "
-            <script>
-                window.location='index.php';
-                alert('Password has been updated successfully');
-            </script>" ;
-	}  
+    $name   = $_POST["uname2"] ?? '';
+    $newpwd = $_POST["pass2"] ?? '';
+    $mail   = $_POST["email2"] ?? '';
+    $hash   = password_hash($newpwd, PASSWORD_DEFAULT);
+    $query = mysqli_prepare($link, "SELECT 1 FROM register WHERE username = ? AND email = ?");
+    mysqli_stmt_bind_param($query, 'ss', $name, $mail);
+    mysqli_stmt_execute($query);
+    mysqli_stmt_store_result($query);
+    if(mysqli_stmt_num_rows($query) == 1){
+            $update = mysqli_prepare($link, "UPDATE register SET password = ? WHERE username = ?");
+            mysqli_stmt_bind_param($update, 'ss', $hash, $name);
+            mysqli_stmt_execute($update);
+            echo "
+                <script>
+                    window.location='index.php';
+                    alert('Password has been updated successfully');
+                </script>" ;
+        }
 ?>

--- a/public/views/register.php
+++ b/public/views/register.php
@@ -2,36 +2,37 @@
 		
 		require_once('connect.php');
 
-		$name= $_REQUEST['uname'];
-		$emad= $_REQUEST['ead'];
-		$pass= $_REQUEST['pass'];
-		$repass= $_REQUEST['repass'];
-		$encp =  sha1($pass); 
-		$encrep =  sha1($repass); 
+                $name   = $_POST['uname'] ?? '';
+                $emad   = $_POST['ead'] ?? '';
+                $pass   = $_POST['pass'] ?? '';
+                $repass = $_POST['repass'] ?? '';
 
+                $stmt = mysqli_prepare($link, "SELECT 1 FROM register WHERE username = ?");
+                mysqli_stmt_bind_param($stmt, 's', $name);
+                mysqli_stmt_execute($stmt);
+                mysqli_stmt_store_result($stmt);
 
-		$dup = "select * from register where username ='$name'";
-		$dup1 = mysqli_query($link,$dup); 
-
-		if( mysqli_num_rows($dup1) >=1)  { 
-		    echo "<script> alert('User name is already exists.');
+                if(mysqli_stmt_num_rows($stmt) >= 1) {
+                    echo "<script> alert('User name is already exists.');
                 window.location='signup.php';
-             </script>";  
+             </script>";
 
-		}  
-	    else { 
-            if($encp==$encrep){
-		        $query = "insert into register values ('$name','$encp','$emad')";
-				$result = mysqli_query($link,$query);
+                }
+            else {
+                if($pass === $repass){
+                        $hashed = password_hash($pass, PASSWORD_DEFAULT);
+                        $insert = mysqli_prepare($link, "INSERT INTO register (username, password, email) VALUES (?, ?, ?)");
+                        mysqli_stmt_bind_param($insert, 'sss', $name, $hashed, $emad);
+                        mysqli_stmt_execute($insert);
                 echo "<script>
                     window.location='login.php';
                 </script>";
-            }
-            else{
-                echo "<script>
-                        alert('Password not match');
-                        window.location='signup.php';
-                    </script>";
                 }
+                else{
+                    echo "<script>
+                            alert('Password not match');
+                            window.location='signup.php';
+                        </script>";
+                    }
             }
 		?>


### PR DESCRIPTION
## Summary
- switch registration and login to `password_hash` and `password_verify`
- use mysqli prepared statements when accessing the `register` table
- sanitize username table name on login

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684530ee7a7c8323bd0339e65de14417