### PR TITLE
Add basic PHPUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,12 @@ php/              # PHP environment configuration (.env)
 
 ## Testing
 
+### Node tests
+
 1. Install Node dependencies with `npm install` if you haven't already. The tests rely on the packages defined in `package.json`.
 2. Run `npm test` to execute the Jest test suite located at `backend/index.test.js`.
+
+### PHP tests
+
+1. Install PHP dependencies with `composer install`. This installs PHPUnit defined in `composer.json`.
+2. Run the PHP test suite with `composer test-php` or `vendor/bin/phpunit`.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,13 @@
         "vlucas/phpdotenv": "^5.5",
         "ext-mysqli": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
     "autoload": {
         "classmap": ["public/controllers/"]
+    },
+    "scripts": {
+        "test-php": "phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Gadgeteria Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/public/controllers/UserManager.php
+++ b/public/controllers/UserManager.php
@@ -1,0 +1,41 @@
+<?php
+class UserManager {
+    private $users = [];
+
+    public function __construct(array $users = []) {
+        $this->users = $users;
+    }
+
+    public function register(string $username, string $password, string $email): bool {
+        if (isset($this->users[$username])) {
+            return false; // user exists
+        }
+        $this->users[$username] = [
+            'password' => password_hash($password, PASSWORD_DEFAULT),
+            'email' => $email
+        ];
+        return true;
+    }
+
+    public function login(string $username, string $password): bool {
+        if (!isset($this->users[$username])) {
+            return false;
+        }
+        return password_verify($password, $this->users[$username]['password']);
+    }
+
+    public function resetPassword(string $username, string $email, string $newPassword): bool {
+        if (!isset($this->users[$username])) {
+            return false;
+        }
+        if ($this->users[$username]['email'] !== $email) {
+            return false;
+        }
+        $this->users[$username]['password'] = password_hash($newPassword, PASSWORD_DEFAULT);
+        return true;
+    }
+
+    public function getUsers(): array {
+        return $this->users;
+    }
+}

--- a/tests/UserManagerTest.php
+++ b/tests/UserManagerTest.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../public/controllers/UserManager.php';
+
+class UserManagerTest extends TestCase {
+    public function testRegister() {
+        $um = new UserManager();
+        $this->assertTrue($um->register('alice', 'secret', 'alice@example.com'));
+        $this->assertFalse($um->register('alice', 'other', 'alice@example.com'));
+    }
+
+    public function testLogin() {
+        $um = new UserManager();
+        $um->register('bob', 'pwd', 'bob@example.com');
+        $this->assertTrue($um->login('bob', 'pwd'));
+        $this->assertFalse($um->login('bob', 'wrong'));
+    }
+
+    public function testPasswordReset() {
+        $um = new UserManager();
+        $um->register('carol', 'pass', 'carol@example.com');
+        $this->assertTrue($um->resetPassword('carol', 'carol@example.com', 'new')); 
+        $this->assertTrue($um->login('carol', 'new'));
+        $this->assertFalse($um->resetPassword('carol', 'bad@example.com', 'x'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `UserManager` PHP class
- create a PHPUnit test suite for registering, logging in and resetting a password
- configure composer with PHPUnit and testing script
- describe how to run PHP tests in README
- add `phpunit.xml` configuration

## Testing
- `npm test` *(fails: jest not found)*
- `composer install` *(fails: composer not installed)*
- `vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453a5efc7c83239909a24a73b0d466